### PR TITLE
Fix GitHub profile url

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -398,7 +398,7 @@
       </li>
 
       <li>
-        <a href="'https://github.com/thomasrosen" target="_blank" rel="nofollow" class="umami--click--github">
+        <a href="https://github.com/thomasrosen" target="_blank" rel="nofollow" class="umami--click--github">
           <span class="icon " data-icon="github" style="color: #000000;"></span>
           <span class="text">thomasrosen</span>
         </a>


### PR DESCRIPTION
Currently, the links goes to https://thomasrosen.qiekub.org/'https://github.com/thomasrosen